### PR TITLE
Fixed GraphViz download link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ ipython
 graphviz
 ```
 
-You will also need to have [Graphviz](http://www.graphviz.org/Download..php) installed.
+You will also need to have [Graphviz](http://www.graphviz.org/download/) installed.
 
 Use of the alternative nltk-based rendering engine requires the following packages:
 ```


### PR DESCRIPTION
Just a simple fix in the `README.md`, the download link was linking to a non existing page