### PR TITLE
Updates for Python 3.12 and later

### DIFF
--- a/showast/asts.py
+++ b/showast/asts.py
@@ -19,7 +19,7 @@ def recurse_through_ast(node, handle_ast, handle_terminal, handle_fields, handle
     
     node_fields = zip(
         node._fields,
-        (getattr(node, attr, "") for attr in node._fields)  # FIX: Have default value for missing fields -- AZ
+        (getattr(node, attr, "") for attr in node._fields)
     )
     field_results = []
     for field_name, field_value in node_fields:

--- a/showast/asts.py
+++ b/showast/asts.py
@@ -19,7 +19,7 @@ def recurse_through_ast(node, handle_ast, handle_terminal, handle_fields, handle
     
     node_fields = zip(
         node._fields,
-        (getattr(node, attr) for attr in node._fields)
+        (getattr(node, attr, "") for attr in node._fields)  # FIX: Have default value for missing fields -- AZ
     )
     field_results = []
     for field_name, field_value in node_fields:


### PR DESCRIPTION
This fixes two issues with Python 3.12 and later:

* The `imp` module is deprecated, so we use `importlib` instead
* Some AST fields may not be available, so we treat them as empty instead

Keep up the good work!